### PR TITLE
Updated container image due to model deployment failing.

### DIFF
--- a/inference/inf2-bert-on-sagemaker/inf2_bert_sagemaker.ipynb
+++ b/inference/inf2-bert-on-sagemaker/inf2_bert_sagemaker.ipynb
@@ -781,8 +781,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
+   "display_name": "conda_pytorch_p310",
+   "language": "conta_pytorch_p310",
    "name": "python3"
   },
   "language_info": {
@@ -795,7 +795,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/inference/inf2-bert-on-sagemaker/inf2_bert_sagemaker.ipynb
+++ b/inference/inf2-bert-on-sagemaker/inf2_bert_sagemaker.ipynb
@@ -782,8 +782,8 @@
  "metadata": {
   "kernelspec": {
    "display_name": "conda_pytorch_p310",
-   "language": "conta_pytorch_p310",
-   "name": "python3"
+   "language": "pytorch",
+   "name": "conda_pytorch_p310"
   },
   "language_info": {
    "codemirror_mode": {

--- a/inference/inf2-bert-on-sagemaker/inf2_bert_sagemaker.ipynb
+++ b/inference/inf2-bert-on-sagemaker/inf2_bert_sagemaker.ipynb
@@ -457,7 +457,7 @@
     "from sagemaker.pytorch.model import PyTorchModel\n",
     "from sagemaker.predictor import Predictor\n",
     "\n",
-    "ecr_image = \"763104351884.dkr.ecr.us-east-2.amazonaws.com/pytorch-inference-neuronx:1.13.1-neuronx-py310-sdk2.13.2-ubuntu20.04\"\n",
+    "ecr_image = \"763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-neuronx:2.1.2-neuronx-py310-sdk2.18.1-ubuntu20.04\"\n",
     "\n",
     "pytorch_model = PyTorchModel(\n",
     "    model_data=s3_model_uri,\n",
@@ -465,6 +465,7 @@
     "    source_dir=\"code\",\n",
     "    entry_point=\"inference.py\",\n",
     "    image_uri = ecr_image,\n",
+    "    model_server_workers = 2\n",
     ")\n",
     "\n",
     "# Let SageMaker know that we've already compiled the model via neuron-cc\n",
@@ -780,9 +781,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_pytorch_p310",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda_pytorch_p310"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -794,7 +795,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/inference/inf2-bert-on-sagemaker/inf2_bert_sagemaker.ipynb
+++ b/inference/inf2-bert-on-sagemaker/inf2_bert_sagemaker.ipynb
@@ -782,7 +782,7 @@
  "metadata": {
   "kernelspec": {
    "display_name": "conda_pytorch_p310",
-   "language": "pytorch",
+   "language": "python",
    "name": "conda_pytorch_p310"
   },
   "language_info": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated ECR image. Particularly:
Python version from 1.13.1 to 2.1.2
neuronx sdk from 2.13.2 to 2.18.1

With the previous image the model deployment was failing and giving an error "worker died".

Added the variable model_server_workers = 2 to avoid having more workers than the amount of neuron cores, thus causing more errors in Cloudwatch logs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
